### PR TITLE
Update README.md to provide a clearer and more correct usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,16 @@ Uses [lz-string](https://github.com/pieroxy/lz-string) to compress state before 
 
 #### Usage
 ```js
+import storage from 'redux-persist/lib/storage';
 import createCompressor from 'redux-persist-transform-compress'
 
-const compressor = createCompressor()
-const compressor = createCompressor({ whitelist: ['someGiganticReducer'] }) // or
-const compressor = createCompressor({ blacklist: ['someSpecialReducer'] }) // or
+const compressor = createCompressor()  // or
+const compressor = createCompressor({ whitelist: ['someGiganticReducer'] })  // or
+const compressor = createCompressor({ blacklist: ['someSpecialReducer'] })
 
-persistStore(store, { transforms: [compressor] })
+const persistConfig = {
+  key: 'root',
+  transforms: [compressor],
+  storage,
+};
 ```


### PR DESCRIPTION
The current usage example in `README.md` incorrectly shows the transform being supplied to `persistStore`, whereas it should actually be passed to `persistReducer` via the config. This PR amends this to clarify the proper usage.