### PR TITLE
Update index.d.ts

### DIFF
--- a/type-definitions/index.d.ts
+++ b/type-definitions/index.d.ts
@@ -1,3 +1,3 @@
-import { PersistorConfig, Transform } from "redux-persist";
+import { PersistConfig, Transform } from "redux-persist";
 
-export default function createCompressor<State, Raw> (config?: PersistorConfig): Transform<State, Raw>;
+export default function createCompressor<State, Raw> (config?: PersistConfig): Transform<State, Raw>;


### PR DESCRIPTION
Fix `PersistorConfig` => `PersistConfig`.

No such type is exposed by redux-persist, any app using redux-persist-transform-compress with TypeScript fails to build. It *is* listed in the docs so at some point it may have been public, but its properties are very different from those expected by redux-persist-transform-compress: one prop `enhancer` but no `whitelist` or `blacklist`, both of which the README of redux-persist-transform-compress uses. `PersistConfig` has them though.

I'm new to these libraries. I did test what I could but don't consider it thorough.